### PR TITLE
managed to fix and add noroot when copying files that should not be root

### DIFF
--- a/nginx/7.1/app/provision/setup.sh
+++ b/nginx/7.1/app/provision/setup.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
 
+# noroot
+#
+# noroot allows provision scripts to be run as the default user "www-data" rather than the root
+# since provision scripts are run with root privileges.
+noroot() {
+    sudo -EH -u "www-data" "$@";
+}
+
+
 config="/srv/.global/custom.yml"
 
 if [[ ! -f "${config}" ]]; then
-  cp "/app/config/templates/default.yml" "/srv/.global/custom.yml"
+  noroot cp "/app/config/templates/default.yml" "/srv/.global/custom.yml"
 fi

--- a/nginx/7.2/app/provision/setup.sh
+++ b/nginx/7.2/app/provision/setup.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
 
+# noroot
+#
+# noroot allows provision scripts to be run as the default user "www-data" rather than the root
+# since provision scripts are run with root privileges.
+noroot() {
+    sudo -EH -u "www-data" "$@";
+}
+
+
 config="/srv/.global/custom.yml"
 
 if [[ ! -f "${config}" ]]; then
-  cp "/app/config/templates/default.yml" "/srv/.global/custom.yml"
+  noroot cp "/app/config/templates/default.yml" "/srv/.global/custom.yml"
 fi

--- a/nginx/7.3/app/provision/setup.sh
+++ b/nginx/7.3/app/provision/setup.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
 
+# noroot
+#
+# noroot allows provision scripts to be run as the default user "www-data" rather than the root
+# since provision scripts are run with root privileges.
+noroot() {
+    sudo -EH -u "www-data" "$@";
+}
+
+
 config="/srv/.global/custom.yml"
 
 if [[ ! -f "${config}" ]]; then
-  cp "/app/config/templates/default.yml" "/srv/.global/custom.yml"
+  noroot cp "/app/config/templates/default.yml" "/srv/.global/custom.yml"
 fi

--- a/nginx/7.4/app/provision/setup.sh
+++ b/nginx/7.4/app/provision/setup.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
 
+# noroot
+#
+# noroot allows provision scripts to be run as the default user "www-data" rather than the root
+# since provision scripts are run with root privileges.
+noroot() {
+    sudo -EH -u "www-data" "$@";
+}
+
+
 config="/srv/.global/custom.yml"
 
 if [[ ! -f "${config}" ]]; then
-  cp "/app/config/templates/default.yml" "/srv/.global/custom.yml"
+  noroot cp "/app/config/templates/default.yml" "/srv/.global/custom.yml"
 fi


### PR DESCRIPTION
This should fix permissions when copying the default.yml to custom.yml so users can add sites to the project. 